### PR TITLE
update __resource to fxmanifest

### DIFF
--- a/dist/fxmanifest.lua
+++ b/dist/fxmanifest.lua
@@ -1,7 +1,11 @@
-resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
+fx_version 'cerulean'
+
+game { 'gta5' }
+
 files { 
     "config.ini",
     "Newtonsoft.Json.dll",
     "GasStations.json"
 }
+
 client_script "frfuel.net.dll"


### PR DESCRIPTION
This PR replaces the deprecated `__resource.lua` with the new `fxmanifest.lua`